### PR TITLE
feat(archive/tar): increase default limits.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 0.0.3
+
+### 2024-02-13
+
+FEATURES:
+
+* `archive/tar`
+  * Default archive size increased to `1GB`
+  * Default archive file size increased to `250MB`
+  * Add missing option `WithMaxArchiveSize` to set the maximum archive file size
+    that the extraction can accept.
+* `archive/zip`
+  * Add missing option `WithMaxArchiveSize` to set the maximum archive file size
+    that the extraction can accept.
+* `ioutil`
+  * Improve early detection for threshold crossing for `LimitCopy`.
+
 ## 0.0.2
 
 ### 2024-02-13

--- a/compression/archive/tar/README.md
+++ b/compression/archive/tar/README.md
@@ -161,7 +161,7 @@ based on the path and the associated file information.
 
 HeaderProcessorFunc declares the function type used to pre-process Tar item headers.
 
-#### func [ResetHeaderTimes](options.go#L89)
+#### func [ResetHeaderTimes](options.go#L96)
 
 `func ResetHeaderTimes() HeaderProcessorFunc`
 
@@ -174,45 +174,51 @@ Useful to get deterministic output.
 
 Option declares operation functional option.
 
-#### func [WithEmptyDirectories](options.go#L72)
+#### func [WithEmptyDirectories](options.go#L79)
 
 `func WithEmptyDirectories(value bool) Option`
 
 WithEmptyDirectories sets a flag to add directories during compression.
 
-#### func [WithExcludeFilter](options.go#L57)
+#### func [WithExcludeFilter](options.go#L64)
 
 `func WithExcludeFilter(value FileInfoFilterFunc) Option`
 
 WithExcludeFilter defines the function used to determine if an item should
 be excluded from the archive.
 
-#### func [WithHeaderRewritterFunc](options.go#L79)
+#### func [WithHeaderRewritterFunc](options.go#L86)
 
 `func WithHeaderRewritterFunc(value HeaderProcessorFunc) Option`
 
 WithHeaderRewritterFunc sets the Tar item header rewritter interceptor.
 
-#### func [WithIncludeFilter](options.go#L49)
+#### func [WithIncludeFilter](options.go#L56)
 
 `func WithIncludeFilter(value FileInfoFilterFunc) Option`
 
 WithIncludeFilter defines the function used to determine if an item should
 be included in the archive.
 
-#### func [WithMaxEntryCount](options.go#L34)
+#### func [WithMaxArchiveSize](options.go#L34)
+
+`func WithMaxArchiveSize(value uint64) Option`
+
+WithMaxArchiveSize overrides the default maximum archive size.
+
+#### func [WithMaxEntryCount](options.go#L41)
 
 `func WithMaxEntryCount(value uint64) Option`
 
 WithMaxEntryCount overrides the default maximum entry count in the archive (directories and files).
 
-#### func [WithMaxFileSize](options.go#L41)
+#### func [WithMaxFileSize](options.go#L48)
 
 `func WithMaxFileSize(value uint64) Option`
 
 WithMaxFileSize overrides the default maximum file size for compression.
 
-#### func [WithOverwriteFilter](options.go#L65)
+#### func [WithOverwriteFilter](options.go#L72)
 
 `func WithOverwriteFilter(value FileInfoFilterFunc) Option`
 

--- a/compression/archive/tar/const.go
+++ b/compression/archive/tar/const.go
@@ -16,9 +16,9 @@ var (
 
 var (
 	// Maximumn archive size
-	defaultMaxArchiveSize = uint64(1 * 1024 * 1024 * 1024)
+	defaultMaxArchiveSize = uint64(1 << 30) // 1GB
 	// Maximum supported file size for archive creation
-	defaultMaxFileSize = uint64(250 * 1024 * 1024)
+	defaultMaxFileSize = uint64(250 << 20) // 250MB
 	// Maximum entry count
 	defaultMaxEntryCount = uint64(10000)
 )

--- a/compression/archive/tar/options.go
+++ b/compression/archive/tar/options.go
@@ -30,6 +30,13 @@ type FileInfoFilterFunc func(path string, fi fs.FileInfo) bool
 // HeaderProcessorFunc declares the function type used to pre-process Tar item headers.
 type HeaderProcessorFunc func(hdr *tar.Header) *tar.Header
 
+// WithMaxArchiveSize overrides the default maximum archive size.
+func WithMaxArchiveSize(value uint64) Option {
+	return func(o *options) {
+		o.MaxArchiveSize = value
+	}
+}
+
 // WithMaxEntryCount overrides the default maximum entry count in the archive (directories and files).
 func WithMaxEntryCount(value uint64) Option {
 	return func(o *options) {

--- a/compression/archive/zip/README.md
+++ b/compression/archive/zip/README.md
@@ -168,7 +168,7 @@ based on the path and the associated file information.
 
 HeaderProcessorFunc declares the function type used to pre-process ZIP item headers.
 
-#### func [ResetHeaderTimes](options.go#L115)
+#### func [ResetHeaderTimes](options.go#L122)
 
 `func ResetHeaderTimes() HeaderProcessorFunc`
 
@@ -181,7 +181,7 @@ Useful to get deterministic output.
 
 Option declares operation functional option.
 
-#### func [WithCompressFilter](options.go#L75)
+#### func [WithCompressFilter](options.go#L82)
 
 `func WithCompressFilter(value FileInfoFilterFunc) Option`
 
@@ -194,52 +194,58 @@ be compressed into the archive.
 
 WithCompressionLevel defines the compression level used during the compression.
 
-#### func [WithDisableFileSizeCheck](options.go#L105)
+#### func [WithDisableFileSizeCheck](options.go#L112)
 
 `func WithDisableFileSizeCheck(value bool) Option`
 
 WithDisableFileSizeCheck sets a flag to disable the file size check during
 decompression.
 
-#### func [WithEmptyDirectories](options.go#L90)
+#### func [WithEmptyDirectories](options.go#L97)
 
 `func WithEmptyDirectories(value bool) Option`
 
 WithEmptyDirectories sets a flag to add directories during compression.
 
-#### func [WithExcludeFilter](options.go#L67)
+#### func [WithExcludeFilter](options.go#L74)
 
 `func WithExcludeFilter(value FileInfoFilterFunc) Option`
 
 WithExcludeFilter defines the function used to determine if an item should
 be excluded from the archive.
 
-#### func [WithHeaderRewritterFunc](options.go#L97)
+#### func [WithHeaderRewritterFunc](options.go#L104)
 
 `func WithHeaderRewritterFunc(value HeaderProcessorFunc) Option`
 
 WithHeaderRewritterFunc sets the Tar item header rewritter interceptor.
 
-#### func [WithIncludeFilter](options.go#L59)
+#### func [WithIncludeFilter](options.go#L66)
 
 `func WithIncludeFilter(value FileInfoFilterFunc) Option`
 
 WithIncludeFilter defines the function used to determine if an item should
 be included in the archive.
 
-#### func [WithMaxEntryCount](options.go#L44)
+#### func [WithMaxArchiveSize](options.go#L44)
+
+`func WithMaxArchiveSize(value uint64) Option`
+
+WithMaxArchiveSize overrides the default maximum archive size.
+
+#### func [WithMaxEntryCount](options.go#L51)
 
 `func WithMaxEntryCount(value uint64) Option`
 
 WithMaxEntryCount overrides the default maximum entry count in the archive (directories and files).
 
-#### func [WithMaxFileSize](options.go#L51)
+#### func [WithMaxFileSize](options.go#L58)
 
 `func WithMaxFileSize(value uint64) Option`
 
 WithMaxFileSize overrides the default maximum file size for compression.
 
-#### func [WithOverwriteFilter](options.go#L83)
+#### func [WithOverwriteFilter](options.go#L90)
 
 `func WithOverwriteFilter(value FileInfoFilterFunc) Option`
 

--- a/compression/archive/zip/options.go
+++ b/compression/archive/zip/options.go
@@ -40,6 +40,13 @@ func WithCompressionLevel(value int) Option {
 	}
 }
 
+// WithMaxArchiveSize overrides the default maximum archive size.
+func WithMaxArchiveSize(value uint64) Option {
+	return func(o *options) {
+		o.MaxArchiveSize = value
+	}
+}
+
 // WithMaxEntryCount overrides the default maximum entry count in the archive (directories and files).
 func WithMaxEntryCount(value uint64) Option {
 	return func(o *options) {

--- a/ioutil/copy.go
+++ b/ioutil/copy.go
@@ -43,11 +43,12 @@ func LimitCopy(dst io.Writer, src io.Reader, maxSize uint64) (uint64, error) {
 
 		// Add to length
 		writtenLength += uint64(written)
-	}
 
-	// Check max size
-	if writtenLength > maxSize {
-		return writtenLength, ErrTruncatedCopy
+		// Early check max size limit and raise error if needed to prevent
+		// resource exhaustion.
+		if writtenLength > maxSize {
+			return writtenLength, ErrTruncatedCopy
+		}
 	}
 
 	// No error

--- a/ioutil/copy_test.go
+++ b/ioutil/copy_test.go
@@ -6,6 +6,7 @@ package ioutil
 import (
 	"errors"
 	"io"
+	"os"
 	"testing"
 )
 
@@ -115,5 +116,23 @@ func TestLimitCopy(t *testing.T) {
 				return
 			}
 		})
+	}
+}
+
+func TestLimitCopy_earlyCheck(t *testing.T) {
+	t.Parallel()
+
+	r := &zeroReader{}
+	w := io.Discard
+
+	pageSize := os.Getpagesize()
+
+	// Run the LimitCopy function with a maximum size limit of 1024 byte.
+	n, err := LimitCopy(w, r, uint64(pageSize)*2+1)
+	if err == nil {
+		t.Error("LimitCopy() error = nil, wantErr true")
+	}
+	if n != uint64(pageSize)*3 {
+		t.Errorf("LimitCopy() n = %v, want %v", n, pageSize)
 	}
 }


### PR DESCRIPTION
# Context

* `archive/tar`
  * Default archive size increased to `1GB`
  * Default archive file size increased to `250MB`
  * Add missing option `WithMaxArchiveSize` to set the maximum archive file size
    that the extraction can accept.
* `archive/zip`
  * Add missing option `WithMaxArchiveSize` to set the maximum archive file size
    that the extraction can accept.
* `ioutil`
  * Improve early detection for threshold crossing for `LimitCopy`.
