### PR TITLE
feat(archive): create relative symlink in ChrootFS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ FEATURES:
   * `Chroot` ensures that the target directory is an existing directory during
     the initialization
   * Support `SymlinkFS` for FS link operations (Go 1.23)
+  * `Symlink` will create relative links when used in ChrootFS
 
 ## 0.0.3
 

--- a/compression/archive/tar/extract.go
+++ b/compression/archive/tar/extract.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/go-secure-sdk/ioutil"
 	"github.com/DataDog/go-secure-sdk/vfs"
+	"github.com/davecgh/go-spew/spew"
 )
 
 // Extract TAR content from the reader to the given outPath prefix.
@@ -177,7 +178,8 @@ func Extract(r io.Reader, outPath string, opts ...Option) error {
 func processLinks(level, maxRecursionDepth uint64, outPath string, out vfs.FileSystem, symlinks []*tar.Header) error {
 	// Check recursion level
 	if level > maxRecursionDepth {
-		return fmt.Errorf("maximum symlink recursion level reached: %w", ErrAbortedOperation)
+		spew.Dump(symlinks)
+		return fmt.Errorf("maximum symlink recursion level reached (%d): %w", level, ErrAbortedOperation)
 	}
 	if len(symlinks) == 0 {
 		// Fast path

--- a/compression/archive/tar/extract.go
+++ b/compression/archive/tar/extract.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/DataDog/go-secure-sdk/ioutil"
 	"github.com/DataDog/go-secure-sdk/vfs"
-	"github.com/davecgh/go-spew/spew"
 )
 
 // Extract TAR content from the reader to the given outPath prefix.
@@ -178,7 +177,6 @@ func Extract(r io.Reader, outPath string, opts ...Option) error {
 func processLinks(level, maxRecursionDepth uint64, outPath string, out vfs.FileSystem, symlinks []*tar.Header) error {
 	// Check recursion level
 	if level > maxRecursionDepth {
-		spew.Dump(symlinks)
 		return fmt.Errorf("maximum symlink recursion level reached (%d): %w", level, ErrAbortedOperation)
 	}
 	if len(symlinks) == 0 {

--- a/vfs/chroot.go
+++ b/vfs/chroot.go
@@ -322,6 +322,7 @@ func (vfs chrootFS) Symlink(sourcePath, targetName string) error {
 	if err != nil {
 		return fmt.Errorf("symlink path %q is not relative to %q: %w", sourcePath, targetName, err)
 	}
+	symlinkPath := filepath.Join(filepath.Dir(targetName), rel)
 
 	// Ensure the symlink is secure
 	if err := isSecurePath(vfs.unsafeFS, vfs.root, sourcePath); err != nil {
@@ -329,6 +330,9 @@ func (vfs chrootFS) Symlink(sourcePath, targetName string) error {
 	}
 	if err := isSecurePath(vfs.unsafeFS, vfs.root, targetName); err != nil {
 		return &ConstraintError{Op: "symlink", Path: targetName, Err: err}
+	}
+	if err := isSecurePath(vfs.unsafeFS, vfs.root, symlinkPath); err != nil {
+		return &ConstraintError{Op: "symlink", Path: symlinkPath, Err: err}
 	}
 
 	return vfs.unsafeFS.Symlink(rel, targetName)


### PR DESCRIPTION
# Context

* Create relative symlinks using `ChrootFS` by default to ensure the extracted content can be easily moved.