### PR TITLE
test(archive/tar): tar builder testing framework.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.0.5
+
+### Not released yet
+
+FEATURES:
+
+* `archive/tar`
+  * Use a `archive/tar` builder to build tests TAR archives
+
 ## 0.0.4
 
 ### 2024-02-15

--- a/compression/archive/tar/builder/builder.go
+++ b/compression/archive/tar/builder/builder.go
@@ -22,11 +22,13 @@ type ArchiveBuilder struct {
 }
 
 // With applies the given options to the builder.
-func (b *ArchiveBuilder) With(bf ...Option) *ArchiveBuilder {
+func (b *ArchiveBuilder) With(bf ...Option) (*ArchiveBuilder, error) {
 	for _, o := range bf {
-		o(b.tw)
+		if err := o(b.tw); err != nil {
+			return nil, err
+		}
 	}
-	return b
+	return b, nil
 }
 
 // Close closes the tar writer.

--- a/compression/archive/tar/builder/builder.go
+++ b/compression/archive/tar/builder/builder.go
@@ -12,13 +12,13 @@ import (
 // New creates a new tar archive builder.
 func New(w io.Writer) *ArchiveBuilder {
 	return &ArchiveBuilder{
-		tw:             tar.NewWriter(w),
+		tw: tar.NewWriter(w),
 	}
 }
 
 // ArchiveBuilder is a tar archive builder.
 type ArchiveBuilder struct {
-	tw            *tar.Writer
+	tw *tar.Writer
 }
 
 // With applies the given options to the builder.

--- a/compression/archive/tar/builder/builder.go
+++ b/compression/archive/tar/builder/builder.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2024-Present Datadog, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+// Package builder provides a tar archive builder essentially for testing purposes.
+package builder
+
+import (
+	"archive/tar"
+	"io"
+)
+
+// New creates a new tar archive builder.
+func New(w io.Writer) *ArchiveBuilder {
+	return &ArchiveBuilder{
+		tw:             tar.NewWriter(w),
+	}
+}
+
+// ArchiveBuilder is a tar archive builder.
+type ArchiveBuilder struct {
+	tw            *tar.Writer
+}
+
+// With applies the given options to the builder.
+func (b *ArchiveBuilder) With(bf ...Option) *ArchiveBuilder {
+	for _, o := range bf {
+		o(b.tw)
+	}
+	return b
+}
+
+// Close closes the tar writer.
+func (b *ArchiveBuilder) Close() error {
+	return b.tw.Close()
+}

--- a/compression/archive/tar/builder/header.go
+++ b/compression/archive/tar/builder/header.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2024-Present Datadog, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	"archive/tar"
+	"time"
+)
+
+// HeaderModifier is a function that modifies a tar header.
+type HeaderModifier func(h *tar.Header) error
+
+// WithUID sets the UID of the header.
+func WithUID(uid int) HeaderModifier {
+	return func(h *tar.Header) error {
+		h.Uid = uid
+		return nil
+	}
+}
+
+// WithGID sets the GID of the header.
+func WithGID(gid int) HeaderModifier {
+	return func(h *tar.Header) error {
+		h.Gid = gid
+		return nil
+	}
+}
+
+// WithMode sets the mode of the header.
+func WithMode(mode int64) HeaderModifier {
+	return func(h *tar.Header) error {
+		h.Mode = mode
+		return nil
+	}
+}
+
+// WithLinkname sets the link name of the header.
+func WithLinkname(linkname string) HeaderModifier {
+	return func(h *tar.Header) error {
+		h.Linkname = linkname
+		return nil
+	}
+}
+
+// WithSize sets the size of the header.
+func WithSize(size int64) HeaderModifier {
+	return func(h *tar.Header) error {
+		h.Size = size
+		return nil
+	}
+}
+
+// WithTypeflag sets the type flag of the header.
+func WithTypeflag(typeFlag byte) HeaderModifier {
+	return func(h *tar.Header) error {
+		h.Typeflag = typeFlag
+		return nil
+	}
+}
+
+// WithName sets the name of the header.
+func WithName(name string) HeaderModifier {
+	return func(h *tar.Header) error {
+		h.Name = name
+		return nil
+	}
+}
+
+// WithModTime sets the modification time of the header.
+func WithModTime(modTime time.Time) HeaderModifier {
+	return func(h *tar.Header) error {
+		h.ModTime = modTime
+		return nil
+	}
+}
+
+// WithAccessTime sets the access time of the header.
+func WithAccessTime(accessTime time.Time) HeaderModifier {
+	return func(h *tar.Header) error {
+		h.AccessTime = accessTime
+		return nil
+	}
+}
+
+// WithChangeTime sets the change time of the header.
+func WithChangeTime(changeTime time.Time) HeaderModifier {
+	return func(h *tar.Header) error {
+		h.ChangeTime = changeTime
+		return nil
+	}
+}

--- a/compression/archive/tar/builder/option.go
+++ b/compression/archive/tar/builder/option.go
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2024-Present Datadog, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	"archive/tar"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+)
+
+// Option is a function that configures the builder.
+type Option func(tw *tar.Writer) error
+
+// FS adds a file system to the archive.
+func FS(fsys fs.FS) Option {
+	return func(tw *tar.Writer) error {
+		// Ensure the root actually exists before trying to tar it
+		rootFi, err := fs.Stat(fsys, ".")
+		if err != nil {
+			return fmt.Errorf("unable to tar files: %w", err)
+		}
+		if !rootFi.IsDir() {
+			return errors.New("root path must be a directory")
+		}
+
+		return tw.AddFS(fsys)
+	}
+}
+
+// File adds a file to the archive.
+func File(name string, r io.Reader, hm ...HeaderModifier) Option {
+	return func(tw *tar.Writer) error {
+		// Check arguments
+		if r == nil {
+			return errors.New("reader must not be nil")
+		}
+
+		// Read the file data
+		data, err := io.ReadAll(r)
+		if err != nil {
+			return fmt.Errorf("unable to read file data: %w", err)
+		}
+
+		// Create a new file entry
+		hdr := &tar.Header{
+			Name: name,
+			Mode: 0600,
+			Size: int64(len(data)),
+		}
+		for _, m := range hm {
+			if err := m(hdr); err != nil {
+				return fmt.Errorf("unable to modify tar header: %w", err)
+			}
+		}
+
+		// Write the header
+		if err := tw.WriteHeader(hdr); err != nil {
+			return fmt.Errorf("unable to write tar header: %w", err)
+		}
+
+		// Write the file data
+		if _, err := tw.Write(data); err != nil {
+			return fmt.Errorf("unable to write file data: %w", err)
+		}
+
+		return nil
+	}
+}
+
+// Dir adds a directory to the archive.
+func Dir(name string, hm ...HeaderModifier) Option {
+	return func(tw *tar.Writer) error {
+		// Create a new directory entry
+		hdr := &tar.Header{
+			Name: name,
+			Mode: 0700,
+			Typeflag: tar.TypeDir,
+		}
+		for _, m := range hm {
+			if err := m(hdr); err != nil {
+				return fmt.Errorf("unable to modify tar header: %w", err)
+			}
+		}
+
+		// Write the header
+		if err := tw.WriteHeader(hdr); err != nil {
+			return fmt.Errorf("unable to write tar header: %w", err)
+		}
+
+		return nil
+	}
+}
+
+// Hardlink adds a hard link to the archive.
+func Hardlink(name, target string, hm ...HeaderModifier) Option {
+	return func(tw *tar.Writer) error {
+		// Create a new hard link entry
+		hdr := &tar.Header{
+			Name:     name,
+			Linkname: target,
+			Mode:     0600,
+			Typeflag: tar.TypeLink,
+		}
+		for _, m := range hm {
+			if err := m(hdr); err != nil {
+				return fmt.Errorf("unable to modify tar header: %w", err)
+			}
+		}
+
+		// Write the header
+		if err := tw.WriteHeader(hdr); err != nil {
+			return fmt.Errorf("unable to write tar header: %w", err)
+		}
+
+		return nil
+	}
+}
+
+// Symlink adds a symbolic link to the archive.
+func Symlink(name, target string, hm ...HeaderModifier) Option {
+	return func(tw *tar.Writer) error {
+		// Create a new symbolic link entry
+		hdr := &tar.Header{
+			Name:     name,
+			Linkname: target,
+			Mode:     0600,
+			Typeflag: tar.TypeSymlink,
+		}
+		for _, m := range hm {
+			if err := m(hdr); err != nil {
+				return fmt.Errorf("unable to modify tar header: %w", err)
+			}
+		}
+
+		// Write the header
+		if err := tw.WriteHeader(hdr); err != nil {
+			return fmt.Errorf("unable to write tar header: %w", err)
+		}
+
+		return nil
+	}
+}

--- a/compression/archive/tar/builder/option.go
+++ b/compression/archive/tar/builder/option.go
@@ -47,7 +47,7 @@ func File(name string, r io.Reader, hm ...HeaderModifier) Option {
 		// Create a new file entry
 		hdr := &tar.Header{
 			Name: name,
-			Mode: 0600,
+			Mode: 0o600,
 			Size: int64(len(data)),
 		}
 		for _, m := range hm {
@@ -75,8 +75,8 @@ func Dir(name string, hm ...HeaderModifier) Option {
 	return func(tw *tar.Writer) error {
 		// Create a new directory entry
 		hdr := &tar.Header{
-			Name: name,
-			Mode: 0700,
+			Name:     name,
+			Mode:     0o700,
 			Typeflag: tar.TypeDir,
 		}
 		for _, m := range hm {
@@ -101,7 +101,7 @@ func Hardlink(name, target string, hm ...HeaderModifier) Option {
 		hdr := &tar.Header{
 			Name:     name,
 			Linkname: target,
-			Mode:     0600,
+			Mode:     0o600,
 			Typeflag: tar.TypeLink,
 		}
 		for _, m := range hm {
@@ -126,7 +126,7 @@ func Symlink(name, target string, hm ...HeaderModifier) Option {
 		hdr := &tar.Header{
 			Name:     name,
 			Linkname: target,
-			Mode:     0600,
+			Mode:     0o600,
 			Typeflag: tar.TypeSymlink,
 		}
 		for _, m := range hm {

--- a/compression/archive/tar/extract.go
+++ b/compression/archive/tar/extract.go
@@ -142,6 +142,14 @@ func Extract(r io.Reader, outPath string, opts ...Option) error {
 
 			// Use a buffered copy from the file directly
 			if _, err := ioutil.LimitCopy(targetFile, tarReader, dopts.MaxFileSize); err != nil {
+				// Close the target file
+				if err := targetFile.Close(); err != nil {
+					return fmt.Errorf("unable to successfully close %q file: %w", targetPath, err)
+				}
+				// Remove the file
+				if err := out.RemoveAll(targetPath); err != nil {
+					return fmt.Errorf("unable to remove file %q: %w", targetPath, err)
+				}
 				return fmt.Errorf("unable to extract file: %w", err)
 			}
 

--- a/compression/archive/tar/extract_test.go
+++ b/compression/archive/tar/extract_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -426,6 +427,11 @@ func TestExtract_WithRestoreTimes(t *testing.T) {
 func TestExtract_WithRestoreOwner(t *testing.T) {
 	t.Parallel()
 
+	// Skip on Windows
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test on windows")
+	}
+
 	out := &bytes.Buffer{}
 	b, err := builder.New(out).With(
 		builder.File("file.txt", strings.NewReader("hello, world"),
@@ -455,6 +461,11 @@ func TestExtract_WithRestoreOwner(t *testing.T) {
 
 func TestExtract_WithRestoreOwner_WithRemapper(t *testing.T) {
 	t.Parallel()
+
+	// Skip on Windows
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test on windows")
+	}
 
 	t.Run("remap", func(t *testing.T) {
 		out := &bytes.Buffer{}

--- a/compression/archive/tar/extract_test.go
+++ b/compression/archive/tar/extract_test.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -406,7 +407,9 @@ func TestExtract_WithRestoreTimes(t *testing.T) {
 
 	out := &bytes.Buffer{}
 	b, err := builder.New(out).With(
-		builder.File("file.txt", strings.NewReader("hello, world")),
+		builder.File("file.txt", strings.NewReader("hello, world"),
+			builder.WithModTime(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)),
+		),
 	)
 	require.NoError(t, err)
 	require.NotNil(t, b)
@@ -422,7 +425,7 @@ func TestExtract_WithRestoreTimes(t *testing.T) {
 	// Check the file
 	fi, err := root.Lstat("file.txt")
 	require.NoError(t, err)
-	require.NotZero(t, fi.ModTime())
+	require.Equal(t, time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC), fi.ModTime().UTC())
 }
 
 func TestExtract_WithRestoreMode(t *testing.T) {

--- a/compression/archive/tar/extract_test.go
+++ b/compression/archive/tar/extract_test.go
@@ -4,16 +4,20 @@
 package tar
 
 import (
+	"archive/tar"
+	"bytes"
 	"crypto"
 	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"os"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/go-secure-sdk/compression/archive/tar/builder"
 	"github.com/DataDog/go-secure-sdk/crypto/hashutil"
 	"github.com/DataDog/go-secure-sdk/vfs"
 )
@@ -25,7 +29,6 @@ func TestExtract_Golden(t *testing.T) {
 		if err != nil {
 			return err
 		}
-
 		if d.IsDir() {
 			return nil
 		}
@@ -141,4 +144,379 @@ func TestExtract_WithoutOverwrite(t *testing.T) {
 	fh, err = hashutil.FileHash(tmpFS, "evil.sh", crypto.SHA256)
 	require.NoError(t, err)
 	require.Equal(t, "e043927118884a50b17102ae31d3e0e5d6478d52439727eb3f66fc8f99d13a73", hex.EncodeToString(fh))
+}
+
+func fingerprint(t *testing.T, root vfs.FileSystem) string {
+	t.Helper()
+
+	var out strings.Builder
+	err := fs.WalkDir(root, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip the root
+		if path == "." {
+			return nil
+		}
+		if d.IsDir() {
+			out.WriteString(fmt.Sprintf("d:%s\n", path))
+			return nil
+		}
+
+		// Content content hash
+		h, err := hashutil.FileHash(root, path, crypto.SHA256)
+		require.NoError(t, err)
+
+		// Get file info
+		fi, err := root.Lstat(path)
+		require.NoError(t, err)
+
+		if fi.Mode()&os.ModeSymlink != 0 {
+			out.WriteString(fmt.Sprintf("l:%s:%s\n", path, fi.Name()))
+		} else {
+			out.WriteString(fmt.Sprintf("f:%s:%d:%s\n", path, fi.Size(), hex.EncodeToString(h)))
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	return out.String()
+}
+
+func TestExtract_Archive_SizeLimiter(t *testing.T) {
+	t.Parallel()
+
+	out := &bytes.Buffer{}
+	b := builder.New(out).With(
+		builder.File("file.txt", strings.NewReader("hello, world")),
+		builder.File("file2.txt", strings.NewReader("hello, world")),
+		builder.File("file3.txt", strings.NewReader("hello, world")),
+	)
+	require.NoError(t, b.Close())
+
+	tmpDir := t.TempDir()
+	require.Error(t, Extract(out, tmpDir, WithMaxArchiveSize(2)))
+}
+
+
+func TestExtract_Archive_CountLimiter(t *testing.T) {
+	t.Parallel()
+
+	out := &bytes.Buffer{}
+	b := builder.New(out).With(
+		builder.File("file.txt", strings.NewReader("hello, world")),
+		builder.File("file2.txt", strings.NewReader("hello, world")),
+		builder.File("file3.txt", strings.NewReader("hello, world")),
+	)
+	require.NoError(t, b.Close())
+
+	tmpDir := t.TempDir()
+	require.Error(t, Extract(out, tmpDir, WithMaxEntryCount(2)))
+
+	// Create a new file system
+	root, err := vfs.Chroot(tmpDir)
+	require.NoError(t, err)
+
+	fgr := fingerprint(t, root)
+	require.Equal(t, "f:file.txt:12:09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b\nf:file2.txt:12:09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b\n", fgr)
+}
+
+func TestExtract_Archive_ItemSizeLimiter(t *testing.T) {
+	t.Parallel()
+
+	out := &bytes.Buffer{}
+	b := builder.New(out).With(
+		builder.File("file.txt", strings.NewReader("hello, world")),
+		builder.File("file2.txt", strings.NewReader("hello, world")),
+		builder.File("file3.txt", bytes.NewReader(make([]byte, 1<<20))),
+	)
+	require.NoError(t, b.Close())
+
+	tmpDir := t.TempDir()
+	require.Error(t, Extract(out, tmpDir, WithMaxFileSize(16)))
+
+	// Create a new file system
+	root, err := vfs.Chroot(tmpDir)
+	require.NoError(t, err)
+
+	fgr := fingerprint(t, root)
+	require.Equal(t, "f:file.txt:12:09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b\nf:file2.txt:12:09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b\n", fgr)
+}
+
+func TestExtract_Archive_With_Device(t *testing.T) {
+	t.Parallel()
+
+	out := &bytes.Buffer{}
+	b := builder.New(out).With(
+		builder.File("usb0", &bytes.Buffer{}, builder.WithTypeflag(tar.TypeBlock)),
+		builder.File("file.txt", strings.NewReader("hello, world")),
+	)
+	require.NoError(t, b.Close())
+
+	tmpDir := t.TempDir()
+	require.NoError(t, Extract(out, tmpDir))
+
+	// Create a new file system
+	root, err := vfs.Chroot(tmpDir)
+	require.NoError(t, err)
+
+	// The device file should not be extracted
+	require.False(t, root.Exists("usb0"))
+
+	// Check the file
+	data, err := root.ReadFile("file.txt")
+	require.NoError(t, err)
+	require.Equal(t, "hello, world", string(data))
+
+	fgr := fingerprint(t, root)
+	require.Equal(t, "f:file.txt:12:09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b\n", fgr)
+}
+
+func TestExtract_Archive_With_PathTraversal(t *testing.T) {
+	t.Parallel()
+
+	out := &bytes.Buffer{}
+	b := builder.New(out).With(
+		builder.File("../file.txt", strings.NewReader("hello, world")),
+	)
+	require.NoError(t, b.Close())
+
+	tmpDir := t.TempDir()
+	require.Error(t, Extract(out, tmpDir))
+}
+
+func TestExtract_LinkSupport_ErrorOnLoop(t *testing.T) {
+	t.Parallel()
+
+	out := &bytes.Buffer{}
+	b := builder.New(out).With(
+		builder.Symlink("zero", "one"),
+		builder.Symlink("one", "two"),
+		builder.Symlink("two", "zero"),
+	)
+	require.NoError(t, b.Close())
+
+	tmpDir := t.TempDir()
+	require.Error(t, Extract(out, tmpDir))
+}
+
+func TestExtract_Empty(t *testing.T) {
+	t.Parallel()
+
+	out := &bytes.Buffer{}
+	b := builder.New(out).With(
+	)
+	require.NoError(t, b.Close())
+
+	tmpDir := t.TempDir()
+	require.NoError(t, Extract(out, tmpDir))
+
+	// Create a new file system
+	root, err := vfs.Chroot(tmpDir)
+	require.NoError(t, err)
+
+	fgr := fingerprint(t, root)
+	require.Equal(t, "", fgr)
+}
+
+func TestExtract_LinkSupport(t *testing.T) {
+	t.Parallel()
+
+	out := &bytes.Buffer{}
+	b := builder.New(out).With(
+		builder.File("file.txt", strings.NewReader("hello, world")),
+		builder.Symlink("symlink", "./file.txt"),
+	)
+	require.NoError(t, b.Close())
+
+	tmpDir := t.TempDir()
+	require.NoError(t, Extract(out, tmpDir))
+
+	// Create a new file system
+	root, err := vfs.Chroot(tmpDir)
+	require.NoError(t, err)
+
+	// Check the symlink
+	fi, err := root.Lstat("symlink")
+	require.NoError(t, err)
+	require.True(t, fi.Mode()&os.ModeSymlink != 0)
+
+	// Check the file
+	data, err := root.ReadFile("symlink")
+	require.NoError(t, err)
+	require.Equal(t, "hello, world", string(data))
+
+	fgr := fingerprint(t, root)
+	require.Equal(t, "f:file.txt:12:09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b\nl:symlink:symlink\n", fgr)
+}
+
+func TestExtract_HardlinkSupport(t *testing.T) {
+	t.Parallel()
+
+	out := &bytes.Buffer{}
+	b := builder.New(out).With(
+		builder.File("file.txt", strings.NewReader("hello, world")),
+		builder.Hardlink("hardlink", "./file.txt"),
+	)
+	require.NoError(t, b.Close())
+
+	tmpDir := t.TempDir()
+	require.NoError(t, Extract(out, tmpDir))
+
+	// Create a new file system
+	root, err := vfs.Chroot(tmpDir)
+	require.NoError(t, err)
+
+	// Check the symlink
+	fi, err := root.Lstat("hardlink")
+	require.NoError(t, err)
+	require.True(t, fi.Mode()&os.ModeSymlink == 0)
+
+	// Check the file
+	data, err := root.ReadFile("hardlink")
+	require.NoError(t, err)
+	require.Equal(t, "hello, world", string(data))
+
+	fgr := fingerprint(t, root)
+	require.Equal(t, "f:file.txt:12:09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b\nf:hardlink:12:09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b\n", fgr)
+}
+
+func TestExtract_WithRestoreTimes(t *testing.T) {
+	t.Parallel()
+
+	out := &bytes.Buffer{}
+	b := builder.New(out).With(
+		builder.File("file.txt", strings.NewReader("hello, world")),
+	)
+	require.NoError(t, b.Close())
+
+	tmpDir := t.TempDir()
+	require.NoError(t, Extract(out, tmpDir, WithRestoreTimes(true)))
+
+	// Create a new file system
+	root, err := vfs.Chroot(tmpDir)
+	require.NoError(t, err)
+
+	// Check the file
+	fi, err := root.Lstat("file.txt")
+	require.NoError(t, err)
+	require.NotZero(t, fi.ModTime())
+}
+
+func TestExtract_WithRestoreOwner(t *testing.T) {
+	t.Parallel()
+
+	out := &bytes.Buffer{}
+	b := builder.New(out).With(
+		builder.File("file.txt", strings.NewReader("hello, world"),
+			builder.WithUID(os.Getuid()),
+			builder.WithGID(os.Getgid()),
+		),
+	)
+	require.NoError(t, b.Close())
+
+	tmpDir := t.TempDir()
+	require.NoError(t, Extract(out, tmpDir, WithRestoreOwner(true)))
+
+	// Create a new file system
+	root, err := vfs.Chroot(tmpDir)
+	require.NoError(t, err)
+
+	// Check the file
+	fi, err := root.Lstat("file.txt")
+	require.NoError(t, err)
+	require.NotNil(t, fi.Sys())
+	require.IsType(t, &syscall.Stat_t{}, fi.Sys())
+	require.Equal(t, os.Getuid(), int(fi.Sys().(*syscall.Stat_t).Uid))
+	require.Equal(t, os.Getgid(), int(fi.Sys().(*syscall.Stat_t).Gid))
+}
+
+func TestExtract_WithRestoreOwner_WithRemapper(t *testing.T) {
+	t.Parallel()
+
+	t.Run("remap", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		b := builder.New(out).With(
+			builder.File("file.txt", strings.NewReader("hello, world"),
+				builder.WithUID(0),
+				builder.WithGID(0),
+			),
+		)
+		require.NoError(t, b.Close())
+
+		tmpDir := t.TempDir()
+		require.NoError(t, Extract(out, tmpDir, WithRestoreOwner(true), WithUIDGIDMapperFunc(func(uid, gid int) (int, int, error) {
+			return os.Getuid(), os.Getgid(), nil
+		})))
+
+		// Create a new file system
+		root, err := vfs.Chroot(tmpDir)
+		require.NoError(t, err)
+
+		// Check the file
+		fi, err := root.Lstat("file.txt")
+		require.NoError(t, err)
+		require.NotNil(t, fi.Sys())
+		require.IsType(t, &syscall.Stat_t{}, fi.Sys())
+		require.Equal(t, os.Getuid(), int(fi.Sys().(*syscall.Stat_t).Uid))
+		require.Equal(t, os.Getgid(), int(fi.Sys().(*syscall.Stat_t).Gid))
+	})
+
+	t.Run("remap_error", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		b := builder.New(out).With(
+			builder.File("file.txt", strings.NewReader("hello, world"),
+				builder.WithUID(0),
+				builder.WithGID(0),
+			),
+		)
+		require.NoError(t, b.Close())
+
+		tmpDir := t.TempDir()
+		require.Error(t, Extract(out, tmpDir, WithRestoreOwner(true), WithUIDGIDMapperFunc(func(uid, gid int) (int, int, error) {
+			return -1, -1, fmt.Errorf("unable to map UID/GID")
+		})))
+	})
+
+	t.Run("remap_invalid", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		b := builder.New(out).With(
+			builder.File("file.txt", strings.NewReader("hello, world"),
+				builder.WithUID(0),
+				builder.WithGID(0),
+			),
+		)
+		require.NoError(t, b.Close())
+
+		tmpDir := t.TempDir()
+		require.Error(t, Extract(out, tmpDir, WithRestoreOwner(true), WithUIDGIDMapperFunc(func(uid, gid int) (int, int, error) {
+			return -1, -1, nil
+		})))
+	})
+}
+
+func TestExtract_WithRestoreMode(t *testing.T) {
+	t.Parallel()
+
+	out := &bytes.Buffer{}
+	b := builder.New(out).With(
+		builder.File("file.txt", strings.NewReader("hello, world"),
+			builder.WithMode(0400),
+		),
+	)
+	require.NoError(t, b.Close())
+
+	tmpDir := t.TempDir()
+	require.NoError(t, Extract(out, tmpDir))
+
+	// Create a new file system
+	root, err := vfs.Chroot(tmpDir)
+	require.NoError(t, err)
+
+	// Check the file
+	fi, err := root.Lstat("file.txt")
+	require.NoError(t, err)
+	require.Equal(t, fs.FileMode(0400), fi.Mode())
 }

--- a/compression/archive/tar/extract_test.go
+++ b/compression/archive/tar/extract_test.go
@@ -172,7 +172,9 @@ func fingerprint(t *testing.T, root vfs.FileSystem) string {
 		require.NoError(t, err)
 
 		if fi.Mode()&os.ModeSymlink != 0 {
-			out.WriteString(fmt.Sprintf("l:%s:%s\n", path, fi.Name()))
+			target, err := root.ReadLink(path)
+			require.NoError(t, err)
+			out.WriteString(fmt.Sprintf("l:%s:%s\n", path, target))
 		} else {
 			out.WriteString(fmt.Sprintf("f:%s:%d:%s\n", path, fi.Size(), hex.EncodeToString(h)))
 		}
@@ -362,7 +364,7 @@ func TestExtract_LinkSupport(t *testing.T) {
 	require.Equal(t, "hello, world", string(data))
 
 	fgr := fingerprint(t, root)
-	require.Equal(t, "f:file.txt:12:09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b\nl:symlink:symlink\n", fgr)
+	require.Equal(t, "f:file.txt:12:09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b\nl:symlink:file.txt\n", fgr)
 }
 
 func TestExtract_HardlinkSupport(t *testing.T) {

--- a/compression/archive/tar/extract_test.go
+++ b/compression/archive/tar/extract_test.go
@@ -200,7 +200,6 @@ func TestExtract_Archive_SizeLimiter(t *testing.T) {
 	require.Error(t, Extract(out, tmpDir, WithMaxArchiveSize(2)))
 }
 
-
 func TestExtract_Archive_CountLimiter(t *testing.T) {
 	t.Parallel()
 
@@ -306,8 +305,7 @@ func TestExtract_Empty(t *testing.T) {
 	t.Parallel()
 
 	out := &bytes.Buffer{}
-	b := builder.New(out).With(
-	)
+	b := builder.New(out).With()
 	require.NoError(t, b.Close())
 
 	tmpDir := t.TempDir()
@@ -503,7 +501,7 @@ func TestExtract_WithRestoreMode(t *testing.T) {
 	out := &bytes.Buffer{}
 	b := builder.New(out).With(
 		builder.File("file.txt", strings.NewReader("hello, world"),
-			builder.WithMode(0400),
+			builder.WithMode(0o400),
 		),
 	)
 	require.NoError(t, b.Close())
@@ -518,5 +516,5 @@ func TestExtract_WithRestoreMode(t *testing.T) {
 	// Check the file
 	fi, err := root.Lstat("file.txt")
 	require.NoError(t, err)
-	require.Equal(t, fs.FileMode(0400), fi.Mode())
+	require.Equal(t, fs.FileMode(0o400), fi.Mode())
 }

--- a/compression/archive/tar/extract_test.go
+++ b/compression/archive/tar/extract_test.go
@@ -189,11 +189,13 @@ func TestExtract_Archive_SizeLimiter(t *testing.T) {
 	t.Parallel()
 
 	out := &bytes.Buffer{}
-	b := builder.New(out).With(
+	b, err := builder.New(out).With(
 		builder.File("file.txt", strings.NewReader("hello, world")),
 		builder.File("file2.txt", strings.NewReader("hello, world")),
 		builder.File("file3.txt", strings.NewReader("hello, world")),
 	)
+	require.NoError(t, err)
+	require.NotNil(t, b)
 	require.NoError(t, b.Close())
 
 	tmpDir := t.TempDir()
@@ -204,11 +206,13 @@ func TestExtract_Archive_CountLimiter(t *testing.T) {
 	t.Parallel()
 
 	out := &bytes.Buffer{}
-	b := builder.New(out).With(
+	b, err := builder.New(out).With(
 		builder.File("file.txt", strings.NewReader("hello, world")),
 		builder.File("file2.txt", strings.NewReader("hello, world")),
 		builder.File("file3.txt", strings.NewReader("hello, world")),
 	)
+	require.NoError(t, err)
+	require.NotNil(t, b)
 	require.NoError(t, b.Close())
 
 	tmpDir := t.TempDir()
@@ -226,11 +230,13 @@ func TestExtract_Archive_ItemSizeLimiter(t *testing.T) {
 	t.Parallel()
 
 	out := &bytes.Buffer{}
-	b := builder.New(out).With(
+	b, err := builder.New(out).With(
 		builder.File("file.txt", strings.NewReader("hello, world")),
 		builder.File("file2.txt", strings.NewReader("hello, world")),
 		builder.File("file3.txt", bytes.NewReader(make([]byte, 1<<20))),
 	)
+	require.NoError(t, err)
+	require.NotNil(t, b)
 	require.NoError(t, b.Close())
 
 	tmpDir := t.TempDir()
@@ -248,10 +254,12 @@ func TestExtract_Archive_With_Device(t *testing.T) {
 	t.Parallel()
 
 	out := &bytes.Buffer{}
-	b := builder.New(out).With(
+	b, err := builder.New(out).With(
 		builder.File("usb0", &bytes.Buffer{}, builder.WithTypeflag(tar.TypeBlock)),
 		builder.File("file.txt", strings.NewReader("hello, world")),
 	)
+	require.NoError(t, err)
+	require.NotNil(t, b)
 	require.NoError(t, b.Close())
 
 	tmpDir := t.TempDir()
@@ -277,9 +285,11 @@ func TestExtract_Archive_With_PathTraversal(t *testing.T) {
 	t.Parallel()
 
 	out := &bytes.Buffer{}
-	b := builder.New(out).With(
+	b, err := builder.New(out).With(
 		builder.File("../file.txt", strings.NewReader("hello, world")),
 	)
+	require.NoError(t, err)
+	require.NotNil(t, b)
 	require.NoError(t, b.Close())
 
 	tmpDir := t.TempDir()
@@ -290,11 +300,13 @@ func TestExtract_LinkSupport_ErrorOnLoop(t *testing.T) {
 	t.Parallel()
 
 	out := &bytes.Buffer{}
-	b := builder.New(out).With(
+	b, err := builder.New(out).With(
 		builder.Symlink("zero", "one"),
 		builder.Symlink("one", "two"),
 		builder.Symlink("two", "zero"),
 	)
+	require.NoError(t, err)
+	require.NotNil(t, b)
 	require.NoError(t, b.Close())
 
 	tmpDir := t.TempDir()
@@ -305,7 +317,9 @@ func TestExtract_Empty(t *testing.T) {
 	t.Parallel()
 
 	out := &bytes.Buffer{}
-	b := builder.New(out).With()
+	b, err := builder.New(out).With()
+	require.NoError(t, err)
+	require.NotNil(t, b)
 	require.NoError(t, b.Close())
 
 	tmpDir := t.TempDir()
@@ -323,10 +337,12 @@ func TestExtract_LinkSupport(t *testing.T) {
 	t.Parallel()
 
 	out := &bytes.Buffer{}
-	b := builder.New(out).With(
+	b, err := builder.New(out).With(
 		builder.File("file.txt", strings.NewReader("hello, world")),
 		builder.Symlink("symlink", "./file.txt"),
 	)
+	require.NoError(t, err)
+	require.NotNil(t, b)
 	require.NoError(t, b.Close())
 
 	tmpDir := t.TempDir()
@@ -354,10 +370,12 @@ func TestExtract_HardlinkSupport(t *testing.T) {
 	t.Parallel()
 
 	out := &bytes.Buffer{}
-	b := builder.New(out).With(
+	b, err := builder.New(out).With(
 		builder.File("file.txt", strings.NewReader("hello, world")),
 		builder.Hardlink("hardlink", "./file.txt"),
 	)
+	require.NoError(t, err)
+	require.NotNil(t, b)
 	require.NoError(t, b.Close())
 
 	tmpDir := t.TempDir()
@@ -385,9 +403,11 @@ func TestExtract_WithRestoreTimes(t *testing.T) {
 	t.Parallel()
 
 	out := &bytes.Buffer{}
-	b := builder.New(out).With(
+	b, err := builder.New(out).With(
 		builder.File("file.txt", strings.NewReader("hello, world")),
 	)
+	require.NoError(t, err)
+	require.NotNil(t, b)
 	require.NoError(t, b.Close())
 
 	tmpDir := t.TempDir()
@@ -407,12 +427,14 @@ func TestExtract_WithRestoreOwner(t *testing.T) {
 	t.Parallel()
 
 	out := &bytes.Buffer{}
-	b := builder.New(out).With(
+	b, err := builder.New(out).With(
 		builder.File("file.txt", strings.NewReader("hello, world"),
 			builder.WithUID(os.Getuid()),
 			builder.WithGID(os.Getgid()),
 		),
 	)
+	require.NoError(t, err)
+	require.NotNil(t, b)
 	require.NoError(t, b.Close())
 
 	tmpDir := t.TempDir()
@@ -436,12 +458,14 @@ func TestExtract_WithRestoreOwner_WithRemapper(t *testing.T) {
 
 	t.Run("remap", func(t *testing.T) {
 		out := &bytes.Buffer{}
-		b := builder.New(out).With(
+		b, err := builder.New(out).With(
 			builder.File("file.txt", strings.NewReader("hello, world"),
 				builder.WithUID(0),
 				builder.WithGID(0),
 			),
 		)
+		require.NoError(t, err)
+		require.NotNil(t, b)
 		require.NoError(t, b.Close())
 
 		tmpDir := t.TempDir()
@@ -464,12 +488,14 @@ func TestExtract_WithRestoreOwner_WithRemapper(t *testing.T) {
 
 	t.Run("remap_error", func(t *testing.T) {
 		out := &bytes.Buffer{}
-		b := builder.New(out).With(
+		b, err := builder.New(out).With(
 			builder.File("file.txt", strings.NewReader("hello, world"),
 				builder.WithUID(0),
 				builder.WithGID(0),
 			),
 		)
+		require.NoError(t, err)
+		require.NotNil(t, b)
 		require.NoError(t, b.Close())
 
 		tmpDir := t.TempDir()
@@ -480,12 +506,14 @@ func TestExtract_WithRestoreOwner_WithRemapper(t *testing.T) {
 
 	t.Run("remap_invalid", func(t *testing.T) {
 		out := &bytes.Buffer{}
-		b := builder.New(out).With(
+		b, err := builder.New(out).With(
 			builder.File("file.txt", strings.NewReader("hello, world"),
 				builder.WithUID(0),
 				builder.WithGID(0),
 			),
 		)
+		require.NoError(t, err)
+		require.NotNil(t, b)
 		require.NoError(t, b.Close())
 
 		tmpDir := t.TempDir()
@@ -499,11 +527,13 @@ func TestExtract_WithRestoreMode(t *testing.T) {
 	t.Parallel()
 
 	out := &bytes.Buffer{}
-	b := builder.New(out).With(
+	b, err := builder.New(out).With(
 		builder.File("file.txt", strings.NewReader("hello, world"),
 			builder.WithMode(0o400),
 		),
 	)
+	require.NoError(t, err)
+	require.NotNil(t, b)
 	require.NoError(t, b.Close())
 
 	tmpDir := t.TempDir()

--- a/compression/archive/tar/extract_test.go
+++ b/compression/archive/tar/extract_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -447,5 +448,10 @@ func TestExtract_WithRestoreMode(t *testing.T) {
 	// Check the file
 	fi, err := root.Lstat("file.txt")
 	require.NoError(t, err)
-	require.Equal(t, fs.FileMode(0o400), fi.Mode())
+	if runtime.GOOS == "windows" {
+		// Windows does not support file mode entirely
+		require.Equal(t, fs.FileMode(0o444), fi.Mode())
+	} else {
+		require.Equal(t, fs.FileMode(0o400), fi.Mode())
+	}
 }

--- a/compression/archive/tar/extract_unix_test.go
+++ b/compression/archive/tar/extract_unix_test.go
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2024-Present Datadog, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+package tar
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/go-secure-sdk/compression/archive/tar/builder"
+	"github.com/DataDog/go-secure-sdk/vfs"
+)
+
+func TestExtract_WithRestoreOwner(t *testing.T) {
+	t.Parallel()
+
+	out := &bytes.Buffer{}
+	b, err := builder.New(out).With(
+		builder.File("file.txt", strings.NewReader("hello, world"),
+			builder.WithUID(os.Getuid()),
+			builder.WithGID(os.Getgid()),
+		),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	require.NoError(t, b.Close())
+
+	tmpDir := t.TempDir()
+	require.NoError(t, Extract(out, tmpDir, WithRestoreOwner(true)))
+
+	// Create a new file system
+	root, err := vfs.Chroot(tmpDir)
+	require.NoError(t, err)
+
+	// Check the file
+	fi, err := root.Lstat("file.txt")
+	require.NoError(t, err)
+	require.NotNil(t, fi.Sys())
+	require.IsType(t, &syscall.Stat_t{}, fi.Sys())
+	require.Equal(t, os.Getuid(), int(fi.Sys().(*syscall.Stat_t).Uid))
+	require.Equal(t, os.Getgid(), int(fi.Sys().(*syscall.Stat_t).Gid))
+}
+
+func TestExtract_WithRestoreOwner_WithRemapper(t *testing.T) {
+	t.Parallel()
+
+	t.Run("remap", func(t *testing.T) {
+		t.Parallel()
+
+		out := &bytes.Buffer{}
+		b, err := builder.New(out).With(
+			builder.File("file.txt", strings.NewReader("hello, world"),
+				builder.WithUID(0),
+				builder.WithGID(0),
+			),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, b)
+		require.NoError(t, b.Close())
+
+		tmpDir := t.TempDir()
+		require.NoError(t, Extract(out, tmpDir, WithRestoreOwner(true), WithUIDGIDMapperFunc(func(uid, gid int) (int, int, error) {
+			return os.Getuid(), os.Getgid(), nil
+		})))
+
+		// Create a new file system
+		root, err := vfs.Chroot(tmpDir)
+		require.NoError(t, err)
+
+		// Check the file
+		fi, err := root.Lstat("file.txt")
+		require.NoError(t, err)
+		require.NotNil(t, fi.Sys())
+		require.IsType(t, &syscall.Stat_t{}, fi.Sys())
+		require.Equal(t, os.Getuid(), int(fi.Sys().(*syscall.Stat_t).Uid))
+		require.Equal(t, os.Getgid(), int(fi.Sys().(*syscall.Stat_t).Gid))
+	})
+
+	t.Run("remap_error", func(t *testing.T) {
+		t.Parallel()
+
+		out := &bytes.Buffer{}
+		b, err := builder.New(out).With(
+			builder.File("file.txt", strings.NewReader("hello, world"),
+				builder.WithUID(0),
+				builder.WithGID(0),
+			),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, b)
+		require.NoError(t, b.Close())
+
+		tmpDir := t.TempDir()
+		require.Error(t, Extract(out, tmpDir, WithRestoreOwner(true), WithUIDGIDMapperFunc(func(uid, gid int) (int, int, error) {
+			return -1, -1, fmt.Errorf("unable to map UID/GID")
+		})))
+	})
+
+	t.Run("remap_invalid", func(t *testing.T) {
+		t.Parallel()
+
+		out := &bytes.Buffer{}
+		b, err := builder.New(out).With(
+			builder.File("file.txt", strings.NewReader("hello, world"),
+				builder.WithUID(0),
+				builder.WithGID(0),
+			),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, b)
+		require.NoError(t, b.Close())
+
+		tmpDir := t.TempDir()
+		require.Error(t, Extract(out, tmpDir, WithRestoreOwner(true), WithUIDGIDMapperFunc(func(uid, gid int) (int, int, error) {
+			return -1, -1, nil
+		})))
+	})
+}


### PR DESCRIPTION
# Context

* Implement a `archive/tar` builder to abstract test from the underlying archive technique used.
* This is used for testing purposes to get rid of golden testing and gain more control on archive building process.