### PR TITLE
Add an internal only client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/DataDog/go-secure-sdk
 
-go 1.21.0
-toolchain go1.23.7
+go 1.23.0
+
+toolchain go1.24.1
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/net/httpclient/README.md
+++ b/net/httpclient/README.md
@@ -10,6 +10,12 @@ DefaultAuthorizer exposes the default authorizer instance.
 var DefaultAuthorizer = &ssrfAuthorizer{}
 ```
 
+InternalOnlyAuthorizer exposes an authorizer instance that only allows internal addresses.
+
+```golang
+var InternalOnlyAuthorizer = &internalOnlyAuthorizer{}
+```
+
 DefaultClient represents a safe HTTP client instance.
 
 ```golang
@@ -65,6 +71,24 @@ if resp != nil {
 
 ```
 Get "http://169.254.169.254/latest/meta-data/": response filter round trip failed: request filter round trip failed: dial tcp 169.254.169.254:80: tcp4/169.254.169.254:80 is not authorized by the client: "169.254.169.254" address is link local unicast
+```
+
+### func [InternalOnly](client.go#L33)
+
+`func InternalOnly(opts ...Option) *http.Client`
+
+InternalOnly returns an HTTP client that only allows connections to internal IP addresses.
+
+```golang
+c := InternalOnly()
+
+// This will work for internal addresses
+r1, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://127.0.0.1/health", nil)
+// ...
+
+// This will be rejected
+r2, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://8.8.8.8/dns-query", nil)
+// Error: "8.8.8.8" address is not internal
 ```
 
 ### func [UnSafe](client.go#L21)
@@ -178,4 +202,3 @@ WithTimeout sets the client timeout.
 ## Sub Packages
 
 * [mock](./mock): Package mock is a generated GoMock package.
-

--- a/net/httpclient/authorizer.go
+++ b/net/httpclient/authorizer.go
@@ -12,11 +12,16 @@ import (
 )
 
 var _ Authorizer = (*ssrfAuthorizer)(nil)
+var _ Authorizer = (*internalOnlyAuthorizer)(nil)
 
 type ssrfAuthorizer struct{}
+type internalOnlyAuthorizer struct{}
 
 // DefaultAuthorizer exposes the default authorizer instance.
 var DefaultAuthorizer = &ssrfAuthorizer{}
+
+// InternalOnlyAuthorizer exposes an authorizer instance that only allows internal addresses.
+var InternalOnlyAuthorizer = &internalOnlyAuthorizer{}
 
 // IsNetworkAddressAuthorized returns true if the given network/host/port
 // tuple is allowed.
@@ -60,6 +65,48 @@ func (az *ssrfAuthorizer) IsNetworkAddressAuthorized(network, address string) (b
 	return true, nil
 }
 
+// IsNetworkAddressAuthorized returns true if the given network/host/port
+// tuple is allowed.
+func (az *internalOnlyAuthorizer) IsNetworkAddressAuthorized(network, address string) (bool, error) {
+	// Enforce valid network
+	switch network {
+	case "tcp", "tcp4", "tcp6":
+		// Acceptable
+	default:
+		return false, fmt.Errorf("the network %q usage is forbidden by the client policy", network)
+	}
+
+	// Enforce not blank address
+	if address == "" {
+		return false, errors.New("the address can't be blank")
+	}
+
+	// Split host/port if any (TCP connection assumed here.)
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return false, fmt.Errorf("unable to split host and port from address %q: %w", address, err)
+	}
+
+	// Parse IP address from address (This is always an IP address, this
+	// handler is called after a DNS resolution.)
+	ip, err := netip.ParseAddr(host)
+	if err != nil {
+		return false, fmt.Errorf("unable to parse given address %q as an IP: %w", address, err)
+	}
+
+	// Only allow internal addresses
+	switch {
+	case ip.IsLoopback():
+		return true, nil
+	case ip.IsLinkLocalUnicast():
+		return true, nil
+	case ip.IsPrivate():
+		return true, nil
+	default:
+		return false, fmt.Errorf("%q address is not internal", host)
+	}
+}
+
 // IsRequestAuthorized returns true if the request is allowed.
 func (az *ssrfAuthorizer) IsRequestAuthorized(req *http.Request) bool {
 	// No filtering implemented yet.
@@ -68,6 +115,18 @@ func (az *ssrfAuthorizer) IsRequestAuthorized(req *http.Request) bool {
 
 // IsResponseAuthorized returns true if the response is allowed.
 func (az *ssrfAuthorizer) IsResponseAuthorized(res *http.Response) bool {
+	// No filtering implemented yet.
+	return true
+}
+
+// IsRequestAuthorized returns true if the request is allowed.
+func (az *internalOnlyAuthorizer) IsRequestAuthorized(req *http.Request) bool {
+	// No filtering implemented yet.
+	return true
+}
+
+// IsResponseAuthorized returns true if the response is allowed.
+func (az *internalOnlyAuthorizer) IsResponseAuthorized(res *http.Response) bool {
 	// No filtering implemented yet.
 	return true
 }

--- a/net/httpclient/client.go
+++ b/net/httpclient/client.go
@@ -28,6 +28,11 @@ func Safe(opts ...Option) *http.Client {
 	return NewClient(DefaultAuthorizer, opts...)
 }
 
+// InternalOnly returns an HTTP client that only allows connections to internal IP addresses.
+func InternalOnly(opts ...Option) *http.Client {
+	return NewClient(InternalOnlyAuthorizer, opts...)
+}
+
 // NewClient is used to create a safe http client with the given authorizer
 // implementation.
 func NewClient(az Authorizer, opts ...Option) *http.Client {


### PR DESCRIPTION
This PR adds an Authorizer that will only allow internal IPs, the opposite of the ssrfauthorizer.